### PR TITLE
update jmodel notebook with new variable name for time

### DIFF
--- a/docs/sources/model_jmodel_python.ipynb
+++ b/docs/sources/model_jmodel_python.ipynb
@@ -63,7 +63,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "data_file = \"ERA5land_global_t2m_dailyStats_mean_01Deg_2024_08_data.nc\""
+    "data_file = \"era5_data_2016-2017_allm_2t_tp_monthly_unicoords_adjlon_celsius_mm_05deg_trim_ts20250923-065745_hssc-laptop01.nc\""
    ]
   },
   {
@@ -274,7 +274,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "input[\"t2m\"].sel(valid_time=\"2024-08-01\").plot(cmap=\"viridis\")"
+    "input[\"t2m\"].sel(time=\"2016-08-01\").plot(cmap=\"viridis\")"
    ]
   },
   {
@@ -284,7 +284,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "input[\"t2m\"].mean(dim=\"valid_time\").plot(cmap=\"viridis\")"
+    "input[\"t2m\"].mean(dim=\"time\").plot(cmap=\"viridis\")"
    ]
   },
   {
@@ -322,7 +322,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "data[\"R0\"].mean(dim=\"valid_time\").plot(cmap=\"viridis\")"
+    "data[\"R0\"].mean(dim=\"time\").plot(cmap=\"viridis\")"
    ]
   },
   {
@@ -332,7 +332,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "data[\"R0\"].sel(valid_time=\"2024-08-01\").plot(cmap=\"viridis\")"
+    "data[\"R0\"].sel(time=\"2016-08-01\").plot(cmap=\"viridis\")"
    ]
   },
   {
@@ -468,7 +468,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "input[\"t2m\"].mean(dim=\"valid_time\").plot(cmap=\"viridis\")"
+    "input[\"t2m\"].mean(dim=\"time\").plot(cmap=\"viridis\")"
    ]
   },
   {
@@ -496,7 +496,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "data[\"R0\"].mean(dim=\"valid_time\").plot(cmap=\"viridis\")"
+    "data[\"R0\"].mean(dim=\"time\").plot(cmap=\"viridis\")"
    ]
   },
   {
@@ -506,7 +506,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "data[\"R0\"].sel(valid_time=\"2024-08-01\").plot(cmap=\"viridis\")"
+    "data[\"R0\"].sel(time=\"2016-08-01\").plot(cmap=\"viridis\")"
    ]
   },
   {
@@ -541,7 +541,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": ".venv (3.12.3)",
+   "display_name": "model-be",
    "language": "python",
    "name": "python3"
   },
@@ -555,7 +555,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.3"
+   "version": "3.11.11"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
- "valid_time" is replaced by "time" in the data preprocessing
- account for this change of data variable name in the notebook
- we will need some integration tests for data backend - model backend, but I am postponing this until we have both models, to then devise a suitable strategy