### PR TITLE
Typofix to format: Make modelcard parseable without yaml workaround in the frontend codebase

### DIFF
--- a/model_cards/WNV-R0_model_card.yaml
+++ b/model_cards/WNV-R0_model_card.yaml
@@ -91,8 +91,7 @@ maintenance:
   development_approach: Continued methodological updates and model extensions
 
 datasets:
-    - Laboratory experimental data on mosquito-pathogen traits compiled through 
-    systematic literature review
+    - Laboratory experimental data on mosquito-pathogen traits compiled through systematic literature review
     - Copernicus ERA5-Land Climate Data
     - ECDC human West Nile Neuroinvasive disease cases data for validation
 


### PR DESCRIPTION
Hi, this fix would solve needing workaround code on the frontend codebase for this yaml file related to this commit change:

[https://github.com/ssciwr/heiplanet-frontend/commit/7a8019554a90f7988723260a8e8dc612d926dc9b specifically reducing the yaml parsing workaround code in `[frontend/scripts/build-model-metadata.mjs](https://github.com/ssciwr/heiplanet-frontend/commit/7a8019554a90f7988723260a8e8dc612d926dc9b#diff-643f6c75b11043f3f6259a567fc6e3f7698b5a282a7b6e8c42e377ef3f1a82b1)`](https://github.com/ssciwr/heiplanet-frontend/commit/7a8019554a90f7988723260a8e8dc612d926dc9b#diff-643f6c75b11043f3f6259a567fc6e3f7698b5a282a7b6e8c42e377ef3f1a82b1)

I should have requested this MR first, as that commit (on main in frontend) won't work until this one is merged. I'll rerun the builds there once this is done. It's fine as frontend is not pushing a new image until it is successful and the integration tests and relatedly build steps [successfully] stop/block that from happening.